### PR TITLE
Add Korean slash command alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ python combined_search.py
 ```
 
 Configure your slash command's Request URL to point to your server, for example `https://your.server/search`.
-Then use `/search` inside Slack to search across the configured services.
+Use the `/search` command inside Slack to search across the configured services.  
+The app also accepts the Korean variant `/검색` as an alias for `/search`.

--- a/combined_search.py
+++ b/combined_search.py
@@ -144,6 +144,12 @@ def handle_search(ack, respond, command):
 
     respond("\n".join(message_lines))
 
+
+@bolt_app.command("/검색")
+def handle_search_korean(ack, respond, command):
+    """Alias for the /search command using a Korean slash command."""
+    handle_search(ack, respond, command)
+
 @flask_app.route("/search", methods=["POST"])
 def slack_events():
     """Endpoint for Slack slash command requests."""


### PR DESCRIPTION
## Summary
- add a `/검색` command that invokes the existing `/search` handler
- mention `/검색` in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6864d887f8e8832e86128e3592e8a3bc