### PR TITLE
Add link formatting in search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@ python combined_search.py
 ```
 
 Configure your slash command's Request URL to point to your server, for example `https://your.server/search`.
-Then use `/search` inside Slack to search across the configured services.
+Use the `/search` command inside Slack to search across the configured services.
+The app also accepts the Korean variant `/검색` as an alias for `/search`.
+
+Queries can be in Korean, English, Japanese, Chinese, or Spanish. Search
+results appear as indented bullets with clickable links for easy access.
+At the bottom of the response, a tiny built-in language model summarizes the
+most common topics from all results.


### PR DESCRIPTION
## Summary
- mention clickable bullet links in README
- indent search results with bullets in code
- summarize search results with a tiny built-in language model
- update summarizer to better handle Korean, English, Japanese, Chinese and Spanish

## Testing
- `python -m py_compile combined_search.py`


------
https://chatgpt.com/codex/tasks/task_b_6864d887f8e8832e86128e3592e8a3bc